### PR TITLE
Feature/cori

### DIFF
--- a/codar/cheetah/machines.py
+++ b/codar/cheetah/machines.py
@@ -36,6 +36,12 @@ local=Machine('local', launchers.Launcher, "local", "mpiexec")
 titan=Machine('titan', launchers.Launcher, "pbs", "aprun",
               processes_per_node=16, node_exclusive=True)
 
+# TODO: remove node exclusive restriction, which can be avoided on cori
+# using correct sbatch and srun options. As a start just get feature
+# parity with titan.
+cori=Machine('cori', launchers.Launcher, "slurm", "srun",
+             processes_per_node=32, node_exclusive=True)
+
 
 def get_by_name(name):
     assert name == name.lower()

--- a/codar/cheetah/machines.py
+++ b/codar/cheetah/machines.py
@@ -4,6 +4,14 @@ Configuration for machines supported by Codar.
 from codar.cheetah import launchers, exc
 
 
+# Note: not all schedulers support all options, the purpose of this is
+# just basic validation to catch mispelling or completely unsupported
+# options. Some options have different names, we favor PBS naming when
+# possible. For example, queue is mapped to partition on cori/slurm.
+# TODO: deeper validation, probably bring back a scheduler model.
+SCHEDULER_OPTIONS = set(["project", "queue", "constraint", "license"])
+
+
 class Machine(object):
     """Class to represent configuration of a specific Supercomputer or
     workstation, including the scheduler and runner used by the machine.
@@ -12,7 +20,8 @@ class Machine(object):
     separately."""
 
     def __init__(self, name, launcher_class, scheduler_name, runner_name,
-                 processes_per_node=None, node_exclusive=False):
+                 processes_per_node=None, node_exclusive=False,
+                 scheduler_options=None):
         self.name = name
         self.launcher_class = launcher_class
         self.scheduler_name = scheduler_name
@@ -21,11 +30,31 @@ class Machine(object):
         # machines, or just generic options configured by Cheetah?
         self.processes_per_node = processes_per_node
         self.node_exclusive = node_exclusive
+        _check_known_scheduler_options(SCHEDULER_OPTIONS, scheduler_options)
+        self.scheduler_options = scheduler_options or {}
 
     def get_launcher_instance(self, output_directory, num_codes):
         return self.launcher_class(self.name, self.scheduler_name,
                                    self.runner_name, output_directory,
                                    num_codes)
+
+    def get_scheduler_options(self, options):
+        """Validate supplied options and add default values where missing.
+        Returns a new dictionary."""
+        supported_set = set(self.scheduler_options.keys())
+        _check_known_scheduler_options(supported_set, options)
+        new_options = dict(self.scheduler_options)
+        new_options.update(options)
+        return new_options
+
+
+def _check_known_scheduler_options(supported_set, options):
+    if options is None:
+        return
+    unknown = set(options.keys()) - supported_set
+    if unknown:
+        raise ValueError("Unsupported scheduler option(s): "
+                         + ",".join(opt for opt in unknown))
 
 
 # All machine names must be lowercase, to avoid conflicts with class
@@ -33,14 +62,21 @@ class Machine(object):
 # container with all the machines.
 
 local=Machine('local', launchers.Launcher, "local", "mpiexec")
+
 titan=Machine('titan', launchers.Launcher, "pbs", "aprun",
-              processes_per_node=16, node_exclusive=True)
+              processes_per_node=16, node_exclusive=True,
+              scheduler_options=dict(project="",
+                                     queue="debug"))
 
 # TODO: remove node exclusive restriction, which can be avoided on cori
 # using correct sbatch and srun options. As a start just get feature
 # parity with titan.
 cori=Machine('cori', launchers.Launcher, "slurm", "srun",
-             processes_per_node=32, node_exclusive=True)
+             processes_per_node=32, node_exclusive=True,
+             scheduler_options=dict(project="",
+                                    queue="debug",
+                                    constraint="haswell",
+                                    license="SCRATCH,project"))
 
 
 def get_by_name(name):

--- a/codar/cheetah/model.py
+++ b/codar/cheetah/model.py
@@ -50,9 +50,8 @@ class Campaign(object):
     run_post_process_stop_group_on_failure = False
 
     # Schedular options. Not used when using machine 'local', required
-    # if using 'titan'.
-    project = "" # project allocation to use
-    queue = "" # scheduler queue to submit to
+    # when using super computers.
+    scheduler_options = {}
 
     # None means use default
     tau_config = None
@@ -96,6 +95,10 @@ class Campaign(object):
         if self.run_post_process_script is not None:
             self.run_post_process_script = self._experiment_relative_path(
                                                 self.run_post_process_script)
+
+        o = self.scheduler_options.get(machine_name, {})
+        # TODO: deeper validation with knowledge of scheduler
+        self.machine_scheduler_options = self.machine.get_scheduler_options(o)
 
     def _get_machine(self, machine_name):
         machine = None
@@ -171,9 +174,7 @@ class Campaign(object):
                 group_runs,
                 max_procs,
                 processes_per_node=group_ppn,
-                queue=self.queue,
                 nodes=group.nodes,
-                project=self.project,
                 walltime=group.walltime,
                 timeout=group.per_run_timeout,
                 node_exclusive=self.machine.node_exclusive,
@@ -181,7 +182,8 @@ class Campaign(object):
                 kill_on_partial_failure=self.kill_on_partial_failure,
                 run_post_process_script=self.run_post_process_script,
                 run_post_process_stop_on_failure=
-                    self.run_post_process_stop_group_on_failure)
+                    self.run_post_process_stop_group_on_failure,
+                scheduler_options=self.machine_scheduler_options)
 
         # TODO: track directories and ids and add to this file
         all_params_json_path = os.path.join(output_dir, "params.json")

--- a/codar/cheetah/post_process.py
+++ b/codar/cheetah/post_process.py
@@ -1,6 +1,0 @@
-"""
-Module for common post-processing actions.
-"""
-
-
-def collect_

--- a/codar/cheetah/templates.py
+++ b/codar/cheetah/templates.py
@@ -14,12 +14,20 @@ export CODAR_WORKFLOW_RUNNER="{workflow_runner}"
 export CODAR_CHEETAH_WORKFLOW_LOG_LEVEL="{workflow_debug_level}"
 """
 
+
 GROUP_ENV_TEMPLATE = """
 export CODAR_CHEETAH_GROUP_WALLTIME="{walltime}"
 export CODAR_CHEETAH_GROUP_MAX_PROCS="{max_procs}"
+
 export CODAR_CHEETAH_SCHEDULER_ACCOUNT="{account}"
+# queue on PBS, partition on SLURM
 export CODAR_CHEETAH_SCHEDULER_QUEUE="{queue}"
+# SLURM specific options
+export CODAR_CHEETAH_SCHEDULER_CONSTRAINT="{constraint}"
+export CODAR_CHEETAH_SCHEDULER_LICENSE="{license}"
+
 export CODAR_CHEETAH_CAMPAIGN_NAME="{campaign_name}"
+
 export CODAR_CHEETAH_GROUP_NAME="{group_name}"
 export CODAR_CHEETAH_GROUP_NODES="{nodes}"
 export CODAR_CHEETAH_GROUP_NODE_EXCLUSIVE="{node_exclusive}"

--- a/codar/workflow/main.py
+++ b/codar/workflow/main.py
@@ -19,7 +19,8 @@ def parse_args():
     parser.add_argument('--max-procs', type=int)
     parser.add_argument('--max-nodes', type=int)
     parser.add_argument('--processes-per-node', type=int)
-    parser.add_argument('--runner', choices=['mpiexec', 'aprun', 'none'],
+    parser.add_argument('--runner', choices=['mpiexec', 'aprun', 'srun',
+                                             'none'],
                         required=True)
     parser.add_argument('--producer', choices=['file'], default='file')
     parser.add_argument('--producer-input-file')

--- a/codar/workflow/model.py
+++ b/codar/workflow/model.py
@@ -515,3 +515,4 @@ class MPIRunner(Runner):
 
 mpiexec = MPIRunner('mpiexec', '-n')
 aprun = MPIRunner('aprun', '-n')
+srun = MPIRunner('srun', '-n')

--- a/examples/PiExperiment.py
+++ b/examples/PiExperiment.py
@@ -4,14 +4,34 @@ from codar.cheetah import parameters as p
 from datetime import timedelta
 
 class PiExperiment(Campaign):
+    # Used in job names submitted to scheduler.
     name = "pi-small-one-node"
-    # TODO: in future could support multiple executables if needed, with
-    # the idea that they have same input/output/params, but are compiled
-    # with different options. Could be modeled as p.ParamExecutable.
-    codes = [("pi", dict(exe="pi-gmp"))]
-    supported_machines = ['local', 'cori']
 
-    queue = "debug"
+    # This application has a single executable, which we give the
+    # friendly name 'pi' for later reference in parameter specification.
+    # The executable path is taken relative to the application directory
+    # specified on the cheetah command line.
+    codes = [("pi", dict(exe="pi-gmp"))]
+
+    # Document which machines the campaign is designed to run on. An
+    # error will be raised if a different machine is specified on the
+    # cheetah command line.
+    supported_machines = ['local', 'cori', 'titan']
+
+    # Per machine scheduler options. Keys are the machine name, values
+    # are dicts of name value pairs for the options for that machine.
+    # Options must be explicitly supported by Cheetah, this is not
+    # currently a generic mechanism.
+    scheduler_options = {
+        "cori": {
+            "queue": "debug",
+            "constraint": "haswell",
+            "license": "SCRATCH,project",
+        },
+        "titan": {
+            "queue": "debug",
+        }
+    }
 
     run_post_process_script = 'pi-post-run-compare-digits.py'
 
@@ -20,7 +40,7 @@ class PiExperiment(Campaign):
     #run_post_process_stop_group_on_failure = True
 
     sweeps = [
-     p.SweepGroup(name="all-methods-small", nodes=1,
+     p.SweepGroup(name="all-methods-small", nodes=4,
                   walltime=timedelta(minutes=30),
       parameter_groups=
       [p.Sweep([

--- a/examples/PiExperiment.py
+++ b/examples/PiExperiment.py
@@ -7,7 +7,7 @@ class PiExperiment(Campaign):
     # the idea that they have same input/output/params, but are compiled
     # with different options. Could be modeled as p.ParamExecutable.
     codes = [("pi", dict(exe="pi-gmp"))]
-    supported_machines = ['local']
+    supported_machines = ['local', 'cori']
 
     run_post_process_script = 'pi-post-run-compare-digits.py'
 

--- a/examples/PiExperiment.py
+++ b/examples/PiExperiment.py
@@ -1,6 +1,8 @@
 from codar.cheetah import Campaign
 from codar.cheetah import parameters as p
 
+from datetime import timedelta
+
 class PiExperiment(Campaign):
     name = "pi-small-one-node"
     # TODO: in future could support multiple executables if needed, with
@@ -8,6 +10,8 @@ class PiExperiment(Campaign):
     # with different options. Could be modeled as p.ParamExecutable.
     codes = [("pi", dict(exe="pi-gmp"))]
     supported_machines = ['local', 'cori']
+
+    queue = "debug"
 
     run_post_process_script = 'pi-post-run-compare-digits.py'
 
@@ -17,6 +21,7 @@ class PiExperiment(Campaign):
 
     sweeps = [
      p.SweepGroup(name="all-methods-small", nodes=1,
+                  walltime=timedelta(minutes=30),
       parameter_groups=
       [p.Sweep([
         p.ParamCmdLineArg("pi", "method", 1, ["mc", "trap"]),

--- a/examples/exaalt.py
+++ b/examples/exaalt.py
@@ -11,8 +11,10 @@ class Exaalt(Campaign):
     # Note that titan has 16 processes per node
     supported_machines = ['titan']
 
-    project = "CSC242"
-    queue = "batch"
+    scheduler_options = {
+        "titan": { "project": "CSC242",
+                   "queue": "batch" }
+    }
 
     kill_on_partial_failure = True
 

--- a/examples/heat_transfer_small.py
+++ b/examples/heat_transfer_small.py
@@ -31,9 +31,13 @@ class HeatTransfer(Campaign):
     # is usually the case when using an adios stage code.
     kill_on_partial_failure = True
 
-    # Options to pass to the scheduler (PBS or slurm)
-    project = "CSC242"
-    queue = "debug"
+    # Options to pass to the scheduler (PBS or slurm). These are set per
+    # target machine, since likely different options will be needed for
+    # each.
+    scheduler_options = {
+        "titan": { "project": "CSC242",
+                   "queue": "debug" }
+    }
 
     sweeps = [
 

--- a/machine_config/cori/submit-env.sh
+++ b/machine_config/cori/submit-env.sh
@@ -4,4 +4,4 @@ source $MODULESHOME/init/bash
 
 # savanna packages pre-installed on cori
 module load python/3.6-anaconda-4.4 cray-mpich/7.6.0
-spack load adios@1.12.0 flexpath@1.12 
+spack load adios@1.12.0 flexpath@1.12

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+nosetests -v tests/nose
+nosetests --with-doctest -v codar
+
+tests/test-examples.sh
+

--- a/scripts/local/group/cancel.sh
+++ b/scripts/local/group/cancel.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+cd $(dirname $0)
+
+if [ ! -f codar.cheetah.jobid.txt ]; then
+    echo "Job ID file 'codar.cheetah.jobid.txt' not found"
+    exit 1
+fi
+
+kill $(cat codar.cheetah.jobid.txt | cut -d: -f2)

--- a/scripts/pbs/group/cancel.sh
+++ b/scripts/pbs/group/cancel.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd $(dirname $0)
+qdel $(cat codar.cheetah.jobid.txt | cut -d: -f2)

--- a/scripts/slurm/group/cancel.sh
+++ b/scripts/slurm/group/cancel.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd $(dirname $0)
+scancel $(cat codar.cheetah.jobid.txt | cut -d: -f2)

--- a/scripts/slurm/group/run-group.sbatch
+++ b/scripts/slurm/group/run-group.sbatch
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+# Note: slurm uses parent dir of sbatch script as working dir by default
+
+source ../campaign-env.sh
+source group-env.sh
+
+if [ -f "$CODAR_CHEETAH_MACHINE_CONFIG" ]; then
+    source "$CODAR_CHEETAH_MACHINE_CONFIG"
+fi
+
+if [ -n "$CODAR_CHEETAH_GROUP_NODE_EXCLUSIVE" ]; then
+    max_args="--max-nodes=$CODAR_CHEETAH_GROUP_NODES --processes-per-node=$CODAR_CHEETAH_GROUP_PROCESSES_PER_NODE"
+else
+    max_args="--max-procs=$CODAR_CHEETAH_GROUP_MAX_PROCS"
+fi
+
+start=$(date +%s)
+
+# Main application run
+"$CODAR_WORKFLOW_SCRIPT" --runner=$CODAR_WORKFLOW_RUNNER \
+ $max_args \
+ --producer-input-file=fobs.json \
+ --log-file=codar.FOBrun.log \
+ --status-file=codar.workflow.status.json \
+ --log-level=$CODAR_CHEETAH_WORKFLOW_LOG_LEVEL
+
+end=$(date +%s)
+echo $(($end - $start)) > codar.cheetah.walltime.txt
+
+# TODO: Post processing
+#"{post_processing}" "{group_directory}"

--- a/scripts/slurm/group/status.sh
+++ b/scripts/slurm/group/status.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+cd $(dirname $0)
+squeue -j $(cat codar.cheetah.jobid.txt | cut -d: -f2)

--- a/scripts/slurm/group/submit.sh
+++ b/scripts/slurm/group/submit.sh
@@ -13,14 +13,21 @@ fi
 secs=$CODAR_CHEETAH_GROUP_WALLTIME
 SLURM_WALLTIME=$(printf '%02d:%02d:%02d\n' $(($secs/3600)) $(($secs%3600/60)) $(($secs%60)))
 
+extra_args=""
+if [ -n "$CODAR_CHEETAH_SCHEDULER_ACCOUNT" ]; then
+    extra_args="--account $CODAR_CHEETAH_SCHEDULER_ACCOUNT"
+fi
+
+# TODO: add option to us knl and configure filesystems
+# TODO: abstract cori specfic options out of generic slurm dir
 OUTPUT=$(sbatch --parsable \
-        -A $CODAR_CHEETAH_SCHEDULER_ACCOUNT \
-        -p $CODAR_CHEETAH_SCHEDULER_QUEUE \
-        -J "$CODAR_CHEETAH_CAMPAIGN_NAME-$CODAR_CHEETAH_GROUP_NAME" \
-        -N $CODAR_CHEETAH_GROUP_NODES \
-        -t $SLURM_WALLTIME \
-        -C haswell \ # TODO: add option to use knl
-        -L SCRATCH,project \ # TODO: add option to configure filesystems
+        --partition=$CODAR_CHEETAH_SCHEDULER_QUEUE \
+        --job-name="$CODAR_CHEETAH_CAMPAIGN_NAME-$CODAR_CHEETAH_GROUP_NAME" \
+        --nodes=$CODAR_CHEETAH_GROUP_NODES \
+        --time=$SLURM_WALLTIME \
+        --constraint=haswell \
+        --license=SCRATCH,project \
+        $extra_args \
         run-group.sbatch)
 
 rval=$?

--- a/scripts/slurm/group/submit.sh
+++ b/scripts/slurm/group/submit.sh
@@ -19,11 +19,11 @@ if [ -n "$CODAR_CHEETAH_SCHEDULER_ACCOUNT" ]; then
 fi
 
 if [ -n "$CODAR_CHEETAH_SCHEDULER_CONSTRAINT" ]; then
-    extra_args="$extra_args --constraint=haswell $CODAR_CHEETAH_SCHEDULER_CONSTRAINT"
+    extra_args="$extra_args --constraint=$CODAR_CHEETAH_SCHEDULER_CONSTRAINT"
 fi
 
 if [ -n "$CODAR_CHEETAH_SCHEDULER_LICENSE" ]; then
-    extra_args="$extra_args --license=haswell $CODAR_CHEETAH_SCHEDULER_LICENSE"
+    extra_args="$extra_args --license=$CODAR_CHEETAH_SCHEDULER_LICENSE"
 fi
 
 OUTPUT=$(sbatch --parsable \

--- a/scripts/slurm/group/submit.sh
+++ b/scripts/slurm/group/submit.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+cd "$(dirname $0)"
+source ../campaign-env.sh
+source group-env.sh
+
+if [ -f "$CODAR_CHEETAH_MACHINE_CONFIG" ]; then
+    source "$CODAR_CHEETAH_MACHINE_CONFIG"
+fi
+
+# convert walltime from seconds to HH:MM:SS format needed by PBS
+
+secs=$CODAR_CHEETAH_GROUP_WALLTIME
+SLURM_WALLTIME=$(printf '%02d:%02d:%02d\n' $(($secs/3600)) $(($secs%3600/60)) $(($secs%60)))
+
+OUTPUT=$(sbatch --parsable \
+        -A $CODAR_CHEETAH_SCHEDULER_ACCOUNT \
+        -p $CODAR_CHEETAH_SCHEDULER_QUEUE \
+        -J "$CODAR_CHEETAH_CAMPAIGN_NAME-$CODAR_CHEETAH_GROUP_NAME" \
+        -N $CODAR_CHEETAH_GROUP_NODES \
+        -t $SLURM_WALLTIME \
+        -C haswell \ # TODO: add option to use knl
+        -L SCRATCH,project \ # TODO: add option to configure filesystems
+        run-group.sbatch)
+
+rval=$?
+
+if [ $rval != 0 ]; then
+    echo "SUBMIT FAILED:"
+    echo $OUTPUT
+    exit $rval
+fi
+
+JOBID=$OUTPUT
+
+echo "SLURM:$JOBID" > codar.cheetah.jobid.txt

--- a/scripts/slurm/group/submit.sh
+++ b/scripts/slurm/group/submit.sh
@@ -18,15 +18,19 @@ if [ -n "$CODAR_CHEETAH_SCHEDULER_ACCOUNT" ]; then
     extra_args="--account $CODAR_CHEETAH_SCHEDULER_ACCOUNT"
 fi
 
-# TODO: add option to us knl and configure filesystems
-# TODO: abstract cori specfic options out of generic slurm dir
+if [ -n "$CODAR_CHEETAH_SCHEDULER_CONSTRAINT" ]; then
+    extra_args="$extra_args --constraint=haswell $CODAR_CHEETAH_SCHEDULER_CONSTRAINT"
+fi
+
+if [ -n "$CODAR_CHEETAH_SCHEDULER_LICENSE" ]; then
+    extra_args="$extra_args --license=haswell $CODAR_CHEETAH_SCHEDULER_LICENSE"
+fi
+
 OUTPUT=$(sbatch --parsable \
         --partition=$CODAR_CHEETAH_SCHEDULER_QUEUE \
         --job-name="$CODAR_CHEETAH_CAMPAIGN_NAME-$CODAR_CHEETAH_GROUP_NAME" \
         --nodes=$CODAR_CHEETAH_GROUP_NODES \
         --time=$SLURM_WALLTIME \
-        --constraint=haswell \
-        --license=SCRATCH,project \
         $extra_args \
         run-group.sbatch)
 

--- a/scripts/slurm/group/wait.sh
+++ b/scripts/slurm/group/wait.sh
@@ -3,7 +3,7 @@
 cd $(dirname $0)
 JOBID=$(cat codar.cheetah.jobid.txt | cut -d: -f2)
 while true; do
-    state=$(squeue -o '%t' $JOBID)
+    state=$(squeue -o '%t' -j $JOBID)
     case "$state" in
     BF|CA|CD|F|NF|PR|TO)
         break

--- a/scripts/slurm/group/wait.sh
+++ b/scripts/slurm/group/wait.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+cd $(dirname $0)
+JOBID=$(cat codar.cheetah.jobid.txt | cut -d: -f2)
+while true; do
+    state=$(squeue -o '%t' $JOBID)
+    case "$state" in
+    BF|CA|CD|F|NF|PR|TO)
+        break
+        ;;
+    esac
+    sleep 1
+done
+cat codar.cheetah.walltime.txt

--- a/scripts/slurm/run-all.sh
+++ b/scripts/slurm/run-all.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+function error_exit
+{
+	echo "$1" 1>&2
+	exit 1
+}
+
+cd $(dirname $0)
+source campaign-env.sh || error_exit "Failed to load compaign-env.sh, aborting"
+
+if [ -z "$CODAR_CHEETAH_EXPERIMENT_DIR" ]; then
+    error_exit "Missing env var CODAR_CHEETAH_EXPERIMENT_DIR, aborting"
+fi
+
+cd $CODAR_CHEETAH_EXPERIMENT_DIR || exit_exit "Missing experiment dir '$CODAR_CHEETAH_EXPERIMENT_DIR', aborting"
+start=$(date +%s)
+group_dirs=$(find . -maxdepth 1 -mindepth 1 -type d)
+for group_dir in $group_dirs; do
+    echo -n "Start $group_dir ... "
+    cd "$group_dir" || exit_exit "Missing group dir '$group_dir', aborting"
+    ./submit.sh || exit_exit "Failed to submit group '$group_dir', aborting"
+    ./wait.sh
+    cd ..
+done
+end=$(date +%s)
+echo $(($end - $start)) > codar.cheetah.walltime.txt

--- a/tests/nose/test_cheetah/__init__.py
+++ b/tests/nose/test_cheetah/__init__.py
@@ -1,0 +1,6 @@
+import os.path
+
+from codar.cheetah.config import CHEETAH_PATH
+
+TEST_OUTPUT_DIR = os.path.join(CHEETAH_PATH, 'test_output', 'nose',
+                               'test_cheetah')

--- a/tests/nose/test_cheetah/test_model.py
+++ b/tests/nose/test_cheetah/test_model.py
@@ -1,0 +1,88 @@
+import os.path
+import shutil
+import json
+
+from nose.tools import assert_equal
+
+from codar.cheetah.model import Campaign
+from codar.cheetah.parameters import SweepGroup, Sweep, ParamCmdLineArg
+
+from test_cheetah import TEST_OUTPUT_DIR
+
+
+class TestCampaign(Campaign):
+    name = 'test_campaign'
+    supported_machines = ['local', 'titan', 'cori']
+    codes = [('test', dict(exe='test'))]
+    sweeps = [
+        SweepGroup(name='test_group', nodes=1, parameter_groups=[
+          Sweep([ParamCmdLineArg('test', 'arg', 1, ['a', 'b'])])
+        ])
+    ]
+
+
+def test_bad_scheduler_options():
+    class BadCampaign(TestCampaign):
+        name = 'bad_scheduler_options'
+        scheduler_options = { 'titan': dict(notanoption='test') }
+
+    try:
+        c = BadCampaign('titan', '/test')
+    except ValueError as e:
+        assert 'notanoption' in str(e), "Bad error message: " + str(e)
+    else:
+        assert False, 'expected ValueError from bad option'
+
+
+def test_default_scheduler_options():
+    class DefaultOptionCampaign(TestCampaign):
+        name = 'default_options'
+        # Alternate license option, use default constraint and queue
+        scheduler_options = { 'cori': dict(license='SCRATCH') }
+
+    c = DefaultOptionCampaign('cori', '/test')
+    assert_equal(c.machine_scheduler_options['license'], 'SCRATCH')
+    assert_equal(c.machine_scheduler_options['constraint'], 'haswell')
+    assert_equal(c.machine_scheduler_options['queue'], 'debug')
+
+
+def test_codes_ordering():
+    class TestMultiExeCampaign(TestCampaign):
+        codes = [('first', dict(exe='testa')),
+                 ('second', dict(exe='testb')),
+                 ('third', dict(exe='testc')),
+                 ('fourth', dict(exe='testd')),
+                 ('fifth', dict(exe='teste')),
+                 ('sixth', dict(exe='testf')),
+                 ('seventh', dict(exe='testg'))]
+        sweeps = [
+            SweepGroup(name='test_group', nodes=1, parameter_groups=[
+              Sweep([
+                ParamCmdLineArg('first', 'arg', 1, ['a', 'b']),
+                ParamCmdLineArg('second', 'arg', 1, ['2']),
+                ParamCmdLineArg('third', 'arg', 1, ['3']),
+                ParamCmdLineArg('fourth', 'arg', 1, ['4']),
+                ParamCmdLineArg('fifth', 'arg', 1, ['5', 'five']),
+                ParamCmdLineArg('sixth', 'arg', 1, ['6']),
+                ParamCmdLineArg('seventh', 'arg', 1, ['7']),
+              ])
+            ])
+        ]
+
+    c = TestMultiExeCampaign('titan', '/test')
+    out_dir = os.path.join(TEST_OUTPUT_DIR,
+                           'test_model', 'test_codes_ordering')
+    fob_path = os.path.join(out_dir, 'test_group', 'fobs.json')
+    shutil.rmtree(out_dir) # clean up any old test output
+    c.make_experiment_run_dir(out_dir)
+
+    correct_order = list(c.codes.keys())
+
+    fobs = []
+    with open(fob_path) as f:
+        for line in f:
+            fobs.append(json.loads(line))
+
+    for fob in fobs:
+        fob_order = [run['name'] for run in fob['runs']]
+        assert_equal(fob_order, correct_order)

--- a/tests/test-examples.sh
+++ b/tests/test-examples.sh
@@ -24,6 +24,11 @@ rm -rf test_output/pi/*
     -a "$CODAR_APPDIR/Example-pi/" \
     -o test_output/pi
 
+rm -rf test_output/cori-pi/*
+./cheetah.py -e examples/PiExperiment.py -m cori \
+    -a "$CODAR_APPDIR/Example-pi/" \
+    -o test_output/cori-pi
+
 rm -rf test_output/heat/*
 ./cheetah.py -e examples/heat_transfer_small.py -m local \
     -a "$CODAR_APPDIR/Example-Heat_Transfer/" \

--- a/tests/test-examples.sh
+++ b/tests/test-examples.sh
@@ -19,15 +19,12 @@ if [ "x$CODAR_APPDIR" == "x" ]; then
     exit 1
 fi
 
-rm -rf test_output/pi/*
-./cheetah.py -e examples/PiExperiment.py -m local \
-    -a "$CODAR_APPDIR/Example-pi/" \
-    -o test_output/pi
-
-rm -rf test_output/cori-pi/*
-./cheetah.py -e examples/PiExperiment.py -m cori \
-    -a "$CODAR_APPDIR/Example-pi/" \
-    -o test_output/cori-pi
+for machine in local titan cori; do
+    rm -rf test_output/$machine-pi/*
+    ./cheetah.py -e examples/PiExperiment.py -m $machine \
+        -a "$CODAR_APPDIR/Example-pi/" \
+        -o test_output/$machine-pi
+done
 
 rm -rf test_output/heat/*
 ./cheetah.py -e examples/heat_transfer_small.py -m local \


### PR DESCRIPTION
Changes spec format re queue and project options, to accommodate different options on different machines. See `examples/PiExample.py` snipet:

```
scheduler_options = {
        "cori": {
            "queue": "debug",
            "constraint": "haswell",
            "license": "SCRATCH,project",
        },
        "titan": {
            "queue": "debug",
        }
    }
```