### PR TITLE
Modified ADIOS param type to include I/O transports

### DIFF
--- a/codar/cheetah/adios_params.py
+++ b/codar/cheetah/adios_params.py
@@ -6,6 +6,7 @@ is an ADIOS specific term.
 
 import xml.etree.cElementTree as ET
 
+
 def adios_xml_transform(xml_filepath, group_name, var_name, value):
     """
     Edit the ADIOS XML file to enable transform (compression/reduction) for a
@@ -28,6 +29,15 @@ def adios_xml_transform(xml_filepath, group_name, var_name, value):
     tag.set('transform', value)
     tree.write(xml_filepath)
 
+
+def adios_xml_transport(xml_filepath, group_name, method_name, method_opts):
+    tree = ET.parse(xml_filepath)
+
+    elem = tree.find('method[@group="' + group_name + '"]')
+    elem.set('method', method_name)
+    elem.text = method_opts
+
+    tree.write(xml_filepath)
 
 #if __name__ == "__main__":
  #   adios_xml_transform("heat:T", "sz", "/Users/kpu/vshare/scratch/heat_transfer.xml")

--- a/codar/cheetah/parameters.py
+++ b/codar/cheetah/parameters.py
@@ -317,18 +317,24 @@ class ParamAdiosXML(Param):
 
     Format:
         adios_transform:<xml_filename>:<group_name>:<var_name>
+        adios_transport:<xml_filename>:<group_name>
 
     Note that the filename is assumed to be relative to the app directory
     specified as a Cheetah command line argument.
     """
-    def __init__(self, target, name, values):
+    def __init__(self, target, name, adios_xml_tags, values):
         Param.__init__(self, target, name, values)
-        parts = name.split(":")
-        if len(parts) != 4 or parts[0] != "adios_transform":
+        parts = adios_xml_tags.split(":")
+        if len(parts) < 3:
             raise ValueError("bad format for ParamAdiosXML name")
+        # param_type = adios_transform or adios_transport
+        self.param_type = parts[0]
         self.xml_filename = parts[1]
         self.group_name = parts[2]
-        self.var_name = parts[3]
+
+        # if param_type is transform
+        if len(parts) == 4:
+            self.var_name = parts[3]
 
 
 class ParamCmdLineOption(Param):

--- a/examples/heat_transfer_simple.py
+++ b/examples/heat_transfer_simple.py
@@ -114,6 +114,10 @@ class HeatTransfer(Campaign):
         p.ParamCmdLineArg("heat", "ysize", 5, [50]),
         p.ParamCmdLineArg("heat", "steps", 6, [6]),
         p.ParamCmdLineArg("heat", "iterations", 7, [5]),
+        p.ParamAdiosXML("heat", "transport", "adios_transport:heat_transfer.xml:heat",
+                        ["MPI_AGGREGATE:num_aggregators=4;num_osts=44",
+                         "POSIX",
+                         "FLEXPATH"]),
         ]),
       ]),
     ]


### PR DESCRIPTION
Added support for adios transport params, which can be used to specify transport methods such as MPI_AGGREGATE, POSIX, FLEXPATH etc. in the adios xml file.

The adios parameter type remains unchanged (edited the existing type name), but added a new _value_ that can be used for the parameter. That is,
now ParamAdiosXML can be adios_transform or adios_transport