### PR TITLE
Feature/workflow scheduling

### DIFF
--- a/codar/workflow/consumer.py
+++ b/codar/workflow/consumer.py
@@ -1,45 +1,63 @@
 """Classes for 'consuming' pipelines - running groups of MPI tasks based on a
 specified total process limit."""
 
-import queue
 import threading
 
 from codar.workflow import status
+from codar.workflow.scheduler import JobList
 
 
 class PipelineRunner(object):
-    """Runner that assumes a homogonous set of nodes, and can be node limited
-    or process limited."""
+    """Runner that assumes a homogonous set of nodes. Now only support only
+    node based limiting (although process limiting can be emulated by setting
+    process_per_node=1 and max_nodes=max_procs).
 
-    def __init__(self, runner, max_procs=None, max_nodes=None,
-                 logger=None, processes_per_node=None, status_file=None):
-        if not (bool(max_procs) ^ bool(max_nodes)):
-            raise ValueError("specify one of max_procs and max_nodes")
-        if max_nodes and processes_per_node is None:
-            raise ValueError("max_nodes requires processes_per_node")
-        self.max_procs = max_procs
+    Threading model: assumes there could be multiple producer threads calling
+    add_pipeline, e.g. if using a dynamic job submission model based on
+    results of previous jobs. Pipelines and each Run in a pipeline are all
+    executed in separate threads, so their notification callbacks execute in
+    separate threads, and their threads must be joined before exiting. The
+    stop and kill_all methods could be called from any of the producer,
+    Pipeline or Run threads."""
+
+    def __init__(self, runner, max_nodes, processes_per_node,
+                 logger=None, status_file=None):
         self.max_nodes = max_nodes
         self.ppn = processes_per_node
         self.runner = runner
-        self.q = queue.Queue()
-        self.pipelines = []
-        self.free_procs = max_procs
-        self.free_nodes = max_nodes
-        self.free_cv = threading.Condition()
         self.logger = logger
-        self._pipeline_ids = set()
-        self._running_pipelines = set()
-        self._state_lock = threading.Lock()
-        self._process_pipelines = True
-        self._allow_new_pipelines = True
-        self._killed = False
+
         if status_file is not None:
             self._status = status.WorkflowStatus(status_file)
         else:
             self._status = None
 
+        self.job_list_cv = threading.Condition()
+        costfn = lambda pipe_or_run: pipe_or_run.get_nodes_used()
+        self.job_list = JobList(costfn)
+
+        self.free_cv = threading.Condition()
+        self.free_nodes = max_nodes
+
+        self.pipelines_lock = threading.Lock()
+        self.pipelines = []
+        self._pipeline_ids = set()
+
+        self._running_pipelines = set()
+        self._process_pipelines = True
+        self._allow_new_pipelines = True
+        self._killed = False
+
     def add_pipeline(self, p):
-        with self._state_lock:
+        p.set_ppn(self.ppn)
+        if p.get_nodes_used() > self.max_nodes:
+            if self.logger:
+                self.logger.error(
+                         "pipeline '%s' requires %d nodes > max %d, skipping",
+                         p.id, p.get_nodes_used(), self.max_nodes)
+            return
+
+        with self.pipelines_lock:
             if not self._allow_new_pipelines:
                 raise ValueError(
                     "new pipelines are not allowed after stop or kill")
@@ -48,18 +66,19 @@ class PipelineRunner(object):
             self._pipeline_ids.add(p.id)
             if self._status is not None:
                 self._status.set_state(p.get_state())
-            self.q.put(p)
+
+        with self.job_list_cv:
+            self.job_list.add_job(p)
+            self.job_list_cv.notify()
 
     def stop(self):
         """Signal to stop when all pipelines are finished. Don't allow adding
         new pipelines."""
-        with self._state_lock:
-            # NB: Queue is thread save, but we don't want to allow a
-            # pipeline to be added at the same time stop is being
-            # executed, which would allow a non-None pipeline to be
-            # appended after the None without raising an error.
-            self._allow_new_pipelines = False
-            self.q.put(None)
+        self._allow_new_pipelines = False
+
+        # signal main thread to wake up and check state
+        with self.job_list_cv:
+            self.job_list_cv.notify()
 
     def kill_all(self):
         """Kill all running processes spawned by this consumer and don't
@@ -68,17 +87,18 @@ class PipelineRunner(object):
         if self.logger is not None:
             self.logger.warn("killing all pipelines and exiting consumer")
 
-        with self._state_lock:
+        with self.pipelines_lock:
             self._killed = True
             self._allow_new_pipelines = False
             self._process_pipelines = False
             still_running = list(self._running_pipelines)
-            self.q.put(None) # unblock queue get in run thread
 
+        # signal both cvs to stop waiting in main thread
         with self.free_cv:
-            # signal pipeline run thread to stop waiting. It checks for
-            # stage change after waking up.
             self.free_cv.notify()
+
+        with self.job_list_cv:
+            self.job_list_cv.notify()
 
         for pipe in still_running:
             pipe.force_kill_all()
@@ -89,22 +109,15 @@ class PipelineRunner(object):
     def run_finished(self, run):
         """Monitor thread(s) should call this as runs complete."""
         with self.free_cv:
-            if self.max_procs is not None:
-                self.logger.debug(
-                    "finished run, free procs %d -> %d",
-                    self.free_procs, self.free_procs + run.nprocs)
-                self.free_procs += run.nprocs
-            else:
-                self.logger.debug(
-                    "finished run, free nodes %d -> %d",
-                    self.free_nodes,
-                    self.free_nodes + pipeline.get_nodes_used())
-                self.free_nodes += run.get_nodes_used()
+            self.logger.debug(
+                "finished run, free nodes %d -> %d",
+                self.free_nodes, self.free_nodes + run.get_nodes_used())
+            self.free_nodes += run.get_nodes_used()
             self.free_cv.notify()
 
     def pipeline_finished(self, pipeline):
         """Monitor thread(s) should call this as pipelines complete."""
-        with self._state_lock:
+        with self.pipelines_lock:
             self._running_pipelines.remove(pipeline)
             if self._status is not None:
                 self._status.set_state(pipeline.get_state())
@@ -114,51 +127,44 @@ class PipelineRunner(object):
             self.logger.error("fatal error in pipeline '%s'" % pipeline.id)
         self.kill_all()
 
-    def _pipeline_can_run(self, pipeline):
-        # NOTE: requires free_cv lock
-        if self.max_procs is not None:
-            return (self.free_procs >= pipeline.total_procs)
-        else:
-            return (self.free_nodes >= pipeline.get_nodes_used())
-
     def run_pipelines(self):
         """Main loop of consumer thread. Does not return until all child
         threads are complete."""
-        # TODO: should client be responsible for setting this in the
-        # JSON input data?
         while True:
-            pipeline = self.q.get() # NB: this blocks on empty queue
-            if pipeline is None:
-                break
-            pipeline.set_ppn(self.ppn)
+            # wait until a job is available or end has been signaled
+            no_more_pipelines = False
+            with self.job_list_cv:
+                while len(self.job_list) == 0:
+                    if not self._allow_new_pipelines:
+                        no_more_pipelines = True
+                        break
+                    self.job_list_cv.wait()
+
+            if no_more_pipelines:
+                self._join_running_pipelines()
+                return
+
+            # wait until nodes are available or quit has been signaled
             with self.free_cv:
-                while not self._pipeline_can_run(pipeline):
-                    # allow exiting wait loop if signaled by another
-                    # thread
+                pipeline = self.job_list.pop_job(self.free_nodes)
+                while pipeline is None:
                     if not self._process_pipelines:
                         break
                     self.free_cv.wait()
+                    pipeline = self.job_list.pop_job(self.free_nodes)
 
                 if self._process_pipelines:
-                    if self.max_procs is not None:
-                        self.logger.debug(
-                            "starting pipeline %s, free procs %d -> %d",
-                            pipeline.id, self.free_procs,
-                            self.free_procs - pipeline.total_procs)
-                        self.free_procs -= pipeline.total_procs
-                    else:
-                        self.logger.debug(
-                            "starting pipeline %s, free nodes %d -> %d",
-                            pipeline.id, self.free_nodes,
-                            self.free_nodes - pipeline.get_nodes_used())
-                        self.free_nodes -= pipeline.get_nodes_used()
+                    self.logger.debug(
+                        "starting pipeline %s, free nodes %d -> %d",
+                        pipeline.id, self.free_nodes,
+                        self.free_nodes - pipeline.get_nodes_used())
+                    self.free_nodes -= pipeline.get_nodes_used()
 
-            with self._state_lock:
-                # check state in case kill was issued while we were
-                # waiting
-                if not self._process_pipelines:
-                    break
+            if not self._process_pipelines:
+                self._join_running_pipelines()
+                return
 
+            with self.pipelines_lock:
                 if self.logger is not None:
                     pipeline.set_loggers(self.logger)
                 pipeline.start(self, self.runner)
@@ -166,10 +172,17 @@ class PipelineRunner(object):
                 if self._status is not None:
                     self._status.set_state(pipeline.get_state())
 
-        # Wait for any pipelines that are still running to complete. Use
-        # a copy since the monitor threads may be removing pipelines as
-        # they complete (and joining an already complete pipeline is
-        # harmless).
+        self._join_running_pipelines()
+
+    def _join_running_pipelines(self):
+        """Wait for any pipelines that are still running to complete. Use
+        a copy since the monitor threads may be removing pipelines as
+        they complete (and joining an already complete pipeline is
+        harmless).
+
+        This must be called without any locks held, since the Pipeline and
+        Run threads may need to acquire them in the callback functions set
+        by the consumer."""
         still_running = list(self._running_pipelines)
         for pipeline in still_running:
             pipeline.join_all()

--- a/codar/workflow/main.py
+++ b/codar/workflow/main.py
@@ -16,9 +16,8 @@ consumer = None
 
 def parse_args():
     parser = argparse.ArgumentParser(description='HPC Worflow script')
-    parser.add_argument('--max-procs', type=int)
-    parser.add_argument('--max-nodes', type=int)
-    parser.add_argument('--processes-per-node', type=int)
+    parser.add_argument('--max-nodes', type=int, required=True)
+    parser.add_argument('--processes-per-node', type=int, required=True)
     parser.add_argument('--runner', choices=['mpiexec', 'aprun', 'srun',
                                              'none'],
                         required=True)
@@ -31,11 +30,6 @@ def parse_args():
     parser.add_argument('--status-file')
 
     args = parser.parse_args()
-
-    if not (bool(args.max_procs) ^ bool(args.max_nodes)):
-        parser.error("specify one of --max-procs and --max-nodes")
-    if args.max_nodes and not args.processes_per_node:
-        parser.error("option --max-nodes requires --processes-per-node")
 
     return args
 
@@ -63,7 +57,6 @@ def main():
         logger = None
 
     consumer = PipelineRunner(runner=runner, logger=logger,
-                              max_procs=args.max_procs,
                               max_nodes=args.max_nodes,
                               processes_per_node=args.processes_per_node,
                               status_file=args.status_file)

--- a/codar/workflow/model.py
+++ b/codar/workflow/model.py
@@ -508,7 +508,7 @@ class Pipeline(object):
             reason = status.REASON_SUCCEEDED
             if any(r.exception for r in self.runs):
                 reason = status.REASON_EXCEPTION
-            elif any(r.timeout for r in self.runs):
+            elif any(r.timed_out for r in self.runs):
                 reason = status.REASON_TIMEOUT
             elif any((r.get_returncode() != 0) for r in self.runs):
                 reason = status.REASON_FAILED

--- a/codar/workflow/scheduler.py
+++ b/codar/workflow/scheduler.py
@@ -1,0 +1,64 @@
+"""
+Classes related to finding a job that can run on available resources. Does
+not assume any knowledge of how long each job will take. Designed for greedy
+search of a job that will fit whenever resources are freed.
+
+In the context of Cheetah workflows, it's unlikely that there will be more than
+a few hundred jobs, so it's not worth optimizing the python search code very
+much. It is however worth making sure that a job is run when resources are
+available, since super computer resources are expensive. Basically it's worth
+doing some work in python to make sure we start a big unit of work on compute
+nodes.
+"""
+
+import bisect
+import threading
+
+
+class JobList(object):
+    """Manage a job list that can find and remove the highest cost job that
+    doesn't exceed max_cost and insert new jobs.
+
+    The job objects can be any type, but a key function must be provided
+    that takes an instance of a job and returns it's cost.
+
+    Uses a coordinated pair of sort list for costs and jobs, along with
+    the bisect module. A linked list might be more efficient, since the
+    list copy on insert and delete may dominate the time to do a linear
+    search of a small list, but it's likely fine either way for the
+    sizes we will encounter."""
+    def __init__(self, costfn, initial_jobs=None):
+        self._costfn = costfn
+        if initial_jobs:
+            self._jobs = list(initial_jobs)
+            self._jobs.sort(key=costfn)
+            self._costs = [costfn(job) for job in self._jobs]
+        else:
+            self._jobs = []
+            self._costs = []
+        self._lock = threading.Lock()
+
+    def add_job(self, job):
+        cost = self._costfn(job)
+        with self._lock:
+            i = bisect.bisect_right(self._costs, cost)
+            self._costs.insert(i, cost)
+            self._jobs.insert(i, job)
+
+    def pop_job(self, max_cost):
+        """Get the highest cost job that doesn't exceed max_cost, and remove
+        it from the job list. Raises IndexError if the job list is empty,
+        returns None if no suitable jobs exist in the list."""
+        with self._lock:
+            if len(self) == 0:
+                raise IndexError('pop called on empty job list')
+            i = bisect.bisect_right(self._costs, max_cost)
+            if i:
+                job = self._jobs[i-1]
+                del self._jobs[i-1]
+                del self._costs[i-1]
+                return job
+            return None
+
+    def __len__(self):
+        return len(self._costs)

--- a/codar/workflow/status.py
+++ b/codar/workflow/status.py
@@ -17,6 +17,7 @@ REASON_TIMEOUT = 'timeout'
 REASON_FAILED = 'failed'
 REASON_SUCCEEDED = 'succeeded'
 REASON_EXCEPTION = 'exception'
+REASON_NOFIT = 'nofit'
 
 
 class WorkflowStatus(object):

--- a/scripts/cobalt/group/run-group.cobalt
+++ b/scripts/cobalt/group/run-group.cobalt
@@ -9,17 +9,12 @@ if [ -f "$CODAR_CHEETAH_MACHINE_CONFIG" ]; then
     source "$CODAR_CHEETAH_MACHINE_CONFIG"
 fi
 
-if [ -n "$CODAR_CHEETAH_GROUP_NODE_EXCLUSIVE" ]; then
-    max_args="--max-nodes=$CODAR_CHEETAH_GROUP_NODES --processes-per-node=$CODAR_CHEETAH_GROUP_PROCESSES_PER_NODE"
-else
-    max_args="--max-procs=$CODAR_CHEETAH_GROUP_MAX_PROCS"
-fi
-
 start=$(date +%s)
 
 # Main application run
 "$CODAR_WORKFLOW_SCRIPT" --runner=$CODAR_WORKFLOW_RUNNER \
- $max_args \
+ --max-nodes=$CODAR_CHEETAH_GROUP_NODES \
+ --processes-per-node=$CODAR_CHEETAH_GROUP_PROCESSES_PER_NODE \
  --producer-input-file=fobs.json \
  --log-file=codar.FOBrun.log \
  --status-file=codar.workflow.status.json \

--- a/scripts/local/group/run-group.sh
+++ b/scripts/local/group/run-group.sh
@@ -9,7 +9,8 @@ start=$(date +%s)
 
 # Main application run
 "$CODAR_WORKFLOW_SCRIPT" --runner=$CODAR_WORKFLOW_RUNNER \
- --max-procs=$CODAR_CHEETAH_GROUP_MAX_PROCS \
+ --max-nodes=$CODAR_CHEETAH_GROUP_MAX_PROCS \
+ --processes-per-node=1 \
  --producer-input-file=fobs.json \
  --log-file=codar.FOBrun.log \
  --status-file=codar.workflow.status.json \

--- a/scripts/pbs/group/run-group.pbs
+++ b/scripts/pbs/group/run-group.pbs
@@ -9,17 +9,12 @@ if [ -f "$CODAR_CHEETAH_MACHINE_CONFIG" ]; then
     source "$CODAR_CHEETAH_MACHINE_CONFIG"
 fi
 
-if [ -n "$CODAR_CHEETAH_GROUP_NODE_EXCLUSIVE" ]; then
-    max_args="--max-nodes=$CODAR_CHEETAH_GROUP_NODES --processes-per-node=$CODAR_CHEETAH_GROUP_PROCESSES_PER_NODE"
-else
-    max_args="--max-procs=$CODAR_CHEETAH_GROUP_MAX_PROCS"
-fi
-
 start=$(date +%s)
 
 # Main application run
 "$CODAR_WORKFLOW_SCRIPT" --runner=$CODAR_WORKFLOW_RUNNER \
- $max_args \
+ --max-nodes=$CODAR_CHEETAH_GROUP_NODES \
+ --processes-per-node=$CODAR_CHEETAH_GROUP_PROCESSES_PER_NODE \
  --producer-input-file=fobs.json \
  --log-file=codar.FOBrun.log \
  --status-file=codar.workflow.status.json \

--- a/scripts/slurm/group/run-group.sbatch
+++ b/scripts/slurm/group/run-group.sbatch
@@ -9,17 +9,12 @@ if [ -f "$CODAR_CHEETAH_MACHINE_CONFIG" ]; then
     source "$CODAR_CHEETAH_MACHINE_CONFIG"
 fi
 
-if [ -n "$CODAR_CHEETAH_GROUP_NODE_EXCLUSIVE" ]; then
-    max_args="--max-nodes=$CODAR_CHEETAH_GROUP_NODES --processes-per-node=$CODAR_CHEETAH_GROUP_PROCESSES_PER_NODE"
-else
-    max_args="--max-procs=$CODAR_CHEETAH_GROUP_MAX_PROCS"
-fi
-
 start=$(date +%s)
 
 # Main application run
 "$CODAR_WORKFLOW_SCRIPT" --runner=$CODAR_WORKFLOW_RUNNER \
- $max_args \
+ --max-nodes=$CODAR_CHEETAH_GROUP_NODES \
+ --processes-per-node=$CODAR_CHEETAH_GROUP_PROCESSES_PER_NODE \
  --producer-input-file=fobs.json \
  --log-file=codar.FOBrun.log \
  --status-file=codar.workflow.status.json \

--- a/tests/common_workflow.py
+++ b/tests/common_workflow.py
@@ -54,7 +54,8 @@ def run_workflow(nruns, ncodes, max_procs, max_nodes, processes_per_node,
             f.write('\n')
 
     if max_procs is not None:
-        max_args = ['--max-procs=%d' % max_procs,
+        # simulate max procs mode, which is no longer supported directly
+        max_args = ['--max-nodes=%d' % max_procs,
                     '--processes-per-node=1']
     else:
         max_args = ['--max-nodes=%d' % max_nodes,

--- a/tests/nose/test_workflow/test_scheduler.py
+++ b/tests/nose/test_workflow/test_scheduler.py
@@ -1,0 +1,23 @@
+
+
+from nose.tools import assert_equal, assert_in
+
+from codar.workflow.scheduler import JobList
+
+
+def test_job_list():
+    jl = JobList(lambda x: x, [23, 2, 256, 17, 99])
+    assert_equal(jl.pop_job(17), 17)
+    assert_equal(jl.pop_job(255), 99)
+    assert_equal(jl.pop_job(50), 23)
+    assert_equal(jl.pop_job(1024), 256)
+    assert_equal(jl.pop_job(1), None)
+    assert_equal(jl.pop_job(256), 2)
+
+    assert_equal(len(jl), 0)
+    try:
+        jl.pop_job(100)
+    except IndexError as e:
+        assert_in('empty', str(e))
+    else:
+        assert False, 'expected IndexError, got no error'

--- a/tests/test-workflow-nofit.py
+++ b/tests/test-workflow-nofit.py
@@ -1,0 +1,37 @@
+#!/usr/bin/env python3
+
+# Test what happens when a FOB that won't fit on given max nodes is
+# submitted to workflow.
+
+import sys
+
+from common_workflow import run_workflow, STATUS_FILE, LOG_FILE
+
+
+if __name__ == '__main__':
+    nruns = 10
+    ncodes = 3
+    max_procs = None
+    max_nodes = 4
+    processes_per_node = 16
+    # 4 * 16 = 64 total procs available, but with node exclusive, they
+    # can't all necessarily be used. In this case, the first code needs
+    # only one proc but still takes one node, second code takes two, and
+    # thrid code also requires two, so 5 nodes are required and only 4
+    # are allowed.
+    codes_nprocs = [1, 32, 17]
+    timeout = 20
+    kill_on_partial_failure = False
+
+    p = run_workflow(nruns, ncodes, max_procs, max_nodes, processes_per_node,
+                     timeout, kill_on_partial_failure,
+                     codes_nprocs=codes_nprocs)
+    p.wait()
+
+    with open(STATUS_FILE) as f:
+        print("STATUS")
+        print(f.read())
+
+    with open(LOG_FILE) as f:
+        print("LOG")
+        print(f.read())


### PR DESCRIPTION
Closes #54. This dramatically improves the node utilization (and execution time) of campaigns like examples/exaalt.py, where many sweeps with different node requirements are part of the same group.

It also removes the --max-procs mode of workflow, since it was confusing to maintain two modes and we don't know of any super computer that has automagic node sharing.

FOBs that can't run with the given max nodes are also handled now. They are marked with state 'not_running' and reason 'nofit', and no run is attempted. An error is logged, but execution of other FOBs will continue (assuming any of them fit).