### PR TITLE
ADIOS XML missing declaration fix

### DIFF
--- a/codar/cheetah/adios_params.py
+++ b/codar/cheetah/adios_params.py
@@ -27,7 +27,7 @@ def adios_xml_transform(xml_filepath, group_name, var_name, value):
     tag = tree.find('adios-group[@name="%s"]/global-bounds/var[@name="%s"]'
                     % (group_name, var_name))
     tag.set('transform', value)
-    tree.write(xml_filepath)
+    tree.write(xml_filepath, xml_declaration=True)
 
 
 def adios_xml_transport(xml_filepath, group_name, method_name, method_opts):
@@ -36,8 +36,7 @@ def adios_xml_transport(xml_filepath, group_name, method_name, method_opts):
     elem = tree.find('method[@group="' + group_name + '"]')
     elem.set('method', method_name)
     elem.text = method_opts
-
-    tree.write(xml_filepath)
+    tree.write(xml_filepath, xml_declaration=True)
 
 #if __name__ == "__main__":
  #   adios_xml_transform("heat:T", "sz", "/Users/kpu/vshare/scratch/heat_transfer.xml")


### PR DESCRIPTION
Fixed bug where the adios xml transport and transform functions in Cheetah were writing back the application's xml file without first line containing the xml declaration.

Without the xml declaration, the xml parser in adios was ignoring the paramters being passed to the MPI_AGGREGATE transport method and was setting all ranks as aggregators as default.
This led to sub-optimal I/O performance.

As a fix, now passing the xml_declaration argument to the ElementTree.write() function. Leaving the default encoding to US-ASCII.