### PR TITLE
Fixed bug in string replacement in param config

### DIFF
--- a/codar/cheetah/launchers.py
+++ b/codar/cheetah/launchers.py
@@ -157,7 +157,10 @@ class Launcher(object):
                     # read and modify lines
                     with open(config_filepath) as config_f:
                         for line in config_f:
-                            line = line.replace(pv.match_string, pv.value)
+                            if '=' in line:
+                                k,v = line.strip().split("=")
+                                if k == pv.match_string:
+                                    line = k+"="+str(pv.value)
                             lines.append(line)
                     # rewrite file with modified lines
                     with open(config_filepath, 'w') as config_f:

--- a/codar/cheetah/launchers.py
+++ b/codar/cheetah/launchers.py
@@ -156,9 +156,10 @@ class Launcher(object):
                     lines = []
                     # read and modify lines
                     with open(config_filepath) as config_f:
-                        for line in config_f:
+                        for _line in config_f:
+                            line = _line.strip()
                             if '=' in line:
-                                k,v = line.strip().split("=")
+                                k = line.strip().split("=")[0]
                                 if k == pv.match_string:
                                     line = k+"="+str(pv.value)
                             lines.append(line)


### PR DESCRIPTION
Fix for a bug in existing param config.
Instead of replacing `b` in `a=b`, it was replacing `a`.
