### PR TITLE
add ParamKeyValue

### DIFF
--- a/codar/cheetah/parameters.py
+++ b/codar/cheetah/parameters.py
@@ -362,6 +362,25 @@ class ParamConfig(Param):
         self.match_string = match_string
 
 
+class ParamKeyValue(Param):
+    """
+    Class to represent replacement of the value in a config file with
+    'k = v' formatted lines. This should work with various formats, including
+    fortran namelist and INI, by ignoring lines that don't match the
+    simple k = v pattern. It has the advantage of being flexible, but the
+    disadvantage of not understanding sections or other more complicated
+    structure in config files. Also does not do any quoting - if required,
+    the spec writer should include literal quotes around the values.
+
+    Note that the filename must be added to the inputs list as well, to be
+    copied to each run directory.
+    """
+    def __init__(self, target, name, config_filename, key_name, values):
+        Param.__init__(self, target, name, values)
+        self.config_filename = config_filename
+        self.key_name = key_name
+
+
 class ParamCmdLineOption(Param):
     """Specification for parameters that are based as a labeled command line
     option. The option must contain the prefix, e.g. '--output-file' not

--- a/examples/param_test.py
+++ b/examples/param_test.py
@@ -22,7 +22,7 @@ class param_test(Campaign):
 
     # Files to be copied from app dir to run directories, e.g. for use
     # with ParamConfig and ParamAdiosXML.
-    inputs = ["print1.conf"]
+    inputs = ["print1.conf", "print2.ini"]
 
     # Document which machines the campaign is designed to run on. An
     # error will be raised if a different machine is specified on the
@@ -63,7 +63,9 @@ class param_test(Campaign):
 
         p.ParamCmdLineArg("print2", "arg1", 1, ["1lav"]),
         p.ParamCmdLineArg("print2", "arg2", 2, [2]),
-        p.ParamCmdLineOption("print2", "opt1", "--opt1", [-100, 13])
+        p.ParamCmdLineOption("print2", "opt1", "--opt1", [-100]),
+        p.ParamKeyValue("print2", "kvconfig", "print2.ini", "mykey",
+                        ["cv1", "cv2"]),
         ]),
       ]),
     ]

--- a/examples/param_test/print2.ini
+++ b/examples/param_test/print2.ini
@@ -1,0 +1,3 @@
+mykey = oldvalue ; extra
+
+otherkey = 'somestring'

--- a/examples/param_test/print2.sh
+++ b/examples/param_test/print2.sh
@@ -8,3 +8,6 @@ for i in $(seq 1 $#); do
     echo $i:$1
     shift
 done
+
+echo "print2.ini:"
+cat print2.ini


### PR DESCRIPTION
Easier to use than ParamConfig and still very flexible. Leaving
ParamConfig for now, in case we ever encounter need for non
k-v and non adios replacement (for example, could be used for
other XML file format if the replacement was simple).