### PR TITLE
Support for TAU TRACEDIR

### DIFF
--- a/codar/cheetah/launchers.py
+++ b/codar/cheetah/launchers.py
@@ -189,6 +189,7 @@ class Launcher(object):
                     os.makedirs(tau_profile_dir)
 
                     rc.env["PROFILEDIR"] = tau_profile_dir
+                    rc.env["TRACEDIR"] = tau_profile_dir
 
                     if timeout is not None:
                         rc.timeout = parse_timedelta_seconds(timeout)


### PR DESCRIPTION
Need for TAU env var TRACEDIR for cases where tracing is enabled. Can simply set the TRACEDIR to PROFILEDIR.