### PR TITLE
Runner extra for additional mpi runner options

### DIFF
--- a/codar/cheetah/data/machine_config/theta/submit-env.sh
+++ b/codar/cheetah/data/machine_config/theta/submit-env.sh
@@ -2,4 +2,4 @@
 
 source $MODULESHOME/init/bash
 
-module load intelpython35
+module load cray-python/3.6.1.1

--- a/codar/cheetah/data/scheduler/cobalt/group/run-group.cobalt
+++ b/codar/cheetah/data/scheduler/cobalt/group/run-group.cobalt
@@ -21,6 +21,7 @@ start=$(date +%s)
 
 # Main application run
 "$CODAR_PYTHON" "$CODAR_WORKFLOW_SCRIPT" --runner=$CODAR_WORKFLOW_RUNNER \
+ --runner_extra="$CODAR_RUNNER_EXTRA" \
  --max-nodes=$CODAR_CHEETAH_GROUP_NODES \
  --processes-per-node=$CODAR_CHEETAH_GROUP_PROCESSES_PER_NODE \
  --producer-input-file=fobs.json \

--- a/codar/cheetah/model.py
+++ b/codar/cheetah/model.py
@@ -193,7 +193,7 @@ class Campaign(object):
                 % (machine_name, self.name))
         return machine
 
-    def make_experiment_run_dir(self, output_dir, _check_code_paths=True):
+    def make_experiment_run_dir(self, output_dir, _check_code_paths=True, runner_extra=""):
         """Produce scripts and directory structure for running the experiment.
 
         Directory structure will be a subdirectory for each scheduler group,
@@ -238,6 +238,7 @@ class Campaign(object):
             app_config=self.machine_app_config_script or "",
             workflow_script_path=config.WORKFLOW_SCRIPT,
             workflow_runner=self.machine.runner_name,
+            runner_extra=runner_extra,
             workflow_debug_level="DEBUG",
             umask=(self.umask or ""),
             codar_python=self.python_path,

--- a/codar/cheetah/templates.py
+++ b/codar/cheetah/templates.py
@@ -14,6 +14,7 @@ export CODAR_WORKFLOW_SCRIPT="{workflow_script_path}"
 export CODAR_WORKFLOW_RUNNER="{workflow_runner}"
 export CODAR_CHEETAH_WORKFLOW_LOG_LEVEL="{workflow_debug_level}"
 export CODAR_CHEETAH_UMASK="{umask}"
+export CODAR_RUNNER_EXTRA="{runner_extra}"
 export CODAR_PYTHON="{codar_python}"
 """
 

--- a/codar/savanna/main.py
+++ b/codar/savanna/main.py
@@ -19,9 +19,9 @@ def parse_args():
     parser = argparse.ArgumentParser(description='HPC Worflow script')
     parser.add_argument('--max-nodes', type=int, required=True)
     parser.add_argument('--processes-per-node', type=int, required=True)
-    parser.add_argument('--runner', choices=['mpiexec', 'aprun', 'srun',
-                                             'jsrun','none'],
-                        required=True)
+    parser.add_argument('--runner', choices=['mpiexec', 'aprun', 'srun', 'jsrun','none'], required=True)
+    parser.add_argument('--runner_extra', default="")
+
     parser.add_argument('--producer', choices=['file'], default='file')
     parser.add_argument('--producer-input-file')
     parser.add_argument('--log-file')
@@ -54,6 +54,7 @@ def main():
         # Note: arg parser should have caught this already
         raise ValueError('Unknown runner: %s' % args.runner)
 
+    runner.AddExtra(args.runner_extra)
     logger = logging.getLogger('codar.savanna')
     if args.log_file:
         handler = logging.FileHandler(args.log_file)

--- a/codar/savanna/model.py
+++ b/codar/savanna/model.py
@@ -695,3 +695,4 @@ class Pipeline(object):
         # has been configured and force kill was not called.
         if self._post_thread is not None:
             self._post_thread.join()
+

--- a/codar/savanna/runners.py
+++ b/codar/savanna/runners.py
@@ -15,6 +15,10 @@ class MPIRunner(Runner):
         self.nodes_arg = nodes_arg
         self.tasks_per_node_arg = tasks_per_node_arg
         self.hostfile = hostfile
+        self.runner_extra = []
+
+    def AddExtra(self, runner_extra=""):
+        self.runner_extra += runner_extra.strip().split()
 
     def wrap(self, run, sched_args, find_in_path=True):
         if find_in_path:
@@ -37,7 +41,12 @@ class MPIRunner(Runner):
             runner_args += [self.tasks_per_node_arg, str(run.tasks_per_node)]
         if run.hostfile is not None:
             runner_args += [self.hostfile, str(run.hostfile)]
-        return runner_args + [run.exe] + run.args
+
+        runner_args += self.runner_extra
+        runner_args += [run.exe]
+        runner_args += run.args
+        #return runner_args + [run.exe] + run.args
+        return runner_args
 
 
 class SummitRunner(Runner):
@@ -50,6 +59,10 @@ class SummitRunner(Runner):
         self.rs_per_host_arg = '-r'
         self.launch_distribution_arg = '-d'
         self.bind_arg = '-b'
+        self.runner_extra = []
+
+    def AddExtra(self, runner_extra=""):
+        self.runner_extra += runner_extra.strip().split()
 
     def wrap(self, run, sched_args, find_in_path=True):
         if find_in_path:
@@ -79,7 +92,10 @@ class SummitRunner(Runner):
                        # self.bind_arg, run.summit_params['bind']
                        ]
 
-        return runner_args + [run.exe] + run.args
+        runner_args += self.runner_extra
+        runner_args += [run.exe]
+        runner_args += run.args
+        return runner_args
 
 
 mpiexec = MPIRunner('mpiexec', '-n', hostfile='--hostfile')


### PR DESCRIPTION
This is so the user can give extra command line options to the MPI runner. For example on Theta, to use RDMA, you have to give it the name of your domain in such a way. The changes are not complex. There might be something you want to tweak.