### PR TITLE
Machine-specific sweeps

### DIFF
--- a/codar/cheetah/model.py
+++ b/codar/cheetah/model.py
@@ -33,7 +33,7 @@ from codar.cheetah.parameters import ParamCmdLineArg
 from codar.cheetah.exc import CheetahException
 
 
-RESERVED_CODE_NAMES = set(['post-process'])
+RESERVED_CODE_NAMES = {'post-process'}
 
 
 class Campaign(object):
@@ -205,6 +205,11 @@ class Campaign(object):
                 raise exc.CheetahException(
                         'bad umask, user r-x must be allowed')
             os.umask(umask_int)
+
+        # Get the sweep groups for this machine
+        if type(self.sweeps) == dict:
+            _sweeps = self.sweeps[self.machine.name]
+            self.sweeps = _sweeps
 
         # Create the top level campaign directory
         _output_dir = os.path.abspath(output_dir)

--- a/codar/cheetah/model.py
+++ b/codar/cheetah/model.py
@@ -34,6 +34,7 @@ from codar.cheetah.exc import CheetahException
 
 
 RESERVED_CODE_NAMES = {'post-process'}
+sweeps_any_machine = 'MACHINE_ANY'
 
 
 class Campaign(object):
@@ -208,8 +209,14 @@ class Campaign(object):
 
         # Get the sweep groups for this machine
         if type(self.sweeps) == dict:
-            _sweeps = self.sweeps[self.machine.name]
-            self.sweeps = _sweeps
+            _sweeps_this_mc = self.sweeps.get(self.machine.name, None) or []
+            _sweeps_any_mc = self.sweeps.get(sweeps_any_machine, None) or []
+
+            self.sweeps = []
+            self.sweeps.extend(_sweeps_this_mc)
+            self.sweeps.extend(_sweeps_any_mc)
+
+            assert len(self.sweeps) > 0, "No sweep groups found."
 
         # Create the top level campaign directory
         _output_dir = os.path.abspath(output_dir)

--- a/examples/01-eulers_number/campaign_calc_e.py
+++ b/examples/01-eulers_number/campaign_calc_e.py
@@ -57,7 +57,7 @@ class CalcECampaign(Campaign):
     # directory. Because the 'n' parameter has different meaning for the
     # two methods, we must define separate Sweep groups for each method
     # to avoid running 'factorial' with too many iterations.
-    sweeps = [
+    sweeps = {'MACHINE_ANY':[
      # Sweep group defines a scheduler job. If different numbers of nodes
      # or node configurations are desired, then multiple SweepGroups can
      # be used. For most simple cases, only one is needed.
@@ -82,4 +82,4 @@ class CalcECampaign(Campaign):
                           [64, 128, 256, 512, 1024, 2048, 4096]),
         ]),
       ]),
-    ]
+    ]}

--- a/examples/02-coupling/cheetah-campaign-gpu.py
+++ b/examples/02-coupling/cheetah-campaign-gpu.py
@@ -134,5 +134,5 @@ class ProducerConsumer(Campaign):
                                 )
 
     # Sweep groups to be activated
-    sweeps = [sweepGroup1]
+    sweeps = {'summit': [sweepGroup1]}
 

--- a/examples/02-coupling/cheetah-campaign-simple.py
+++ b/examples/02-coupling/cheetah-campaign-simple.py
@@ -82,5 +82,5 @@ class ProducerConsumer(Campaign):
                                 )
 
     # Sweep groups to be activated
-    sweeps = [sweepGroup1]
+    sweeps = {'summit': [sweepGroup1]}
 

--- a/examples/02-coupling/cheetah-campaign.py
+++ b/examples/02-coupling/cheetah-campaign.py
@@ -105,6 +105,25 @@ class ProducerConsumer(Campaign):
                                 # max_procs = 64 <-- max no. of procs to run concurrently. depends on 'nodes'
                                 )
 
+    # Create a sweep group from the above sweep. You can place multiple sweeps in the group.
+    # Each group is submitted as a separate job.
+    sweepGroup2 = p.SweepGroup ("sg-2",
+                                walltime=300,
+                                per_run_timeout=60,
+                                parameter_groups=[sweep1],
+                                launch_mode='default',  # or MPMD
+                                # optional:
+                                tau_profiling=True,
+                                tau_tracing=False,
+                                # nodes=10,
+                                # tau_profiling=True,
+                                # tau_tracing=False,
+                                # run_repetitions=2, <-- repeat each experiment this many times
+                                # component_subdirs = True, <-- codes have their own separate workspace in the experiment directory
+                                # component_inputs = {'simulation': ['some_input_file'], 'norm_calc': [SymLink('some_large_file')] } <-- inputs required by codes
+                                # max_procs = 64 <-- max no. of procs to run concurrently. depends on 'nodes'
+                                )
+
     # Sweep groups to be activated
-    sweeps = [sweepGroup1]
+    sweeps = {'MACHINE_ANY':[sweepGroup1], 'summit':[sweepGroup2]}
 

--- a/examples/03-brusselator/cheetah-campaign.py
+++ b/examples/03-brusselator/cheetah-campaign.py
@@ -115,5 +115,5 @@ class Brusselator(Campaign):
     sweepGroup2.name = 'sg-2'
     
     # Sweep groups to be activated
-    sweeps = [sweepGroup1, sweepGroup2]
+    sweeps = {'MACHINE_ANY': [sweepGroup1], 'summit':[sweepGroup2]}
 

--- a/examples/04-gray-scott-summit/campaign-spec.py
+++ b/examples/04-gray-scott-summit/campaign-spec.py
@@ -44,5 +44,5 @@ class GrayScott(Campaign):
                                 run_repetitions=2, )
     
     # Activate the SweepGroup
-    sweeps = [sweepGroup1]
+    sweeps = {'summit':[sweepGroup1]}
 

--- a/examples/04-gray-scott/cheetah-campaign-2.py
+++ b/examples/04-gray-scott/cheetah-campaign-2.py
@@ -100,5 +100,5 @@ class GrayScott(Campaign):
                                 )
     
     # Activate the SweepGroup
-    sweeps = [sweepGroup1, sweepGroup2]
+    sweeps = {'MACHINE_ANY':[sweepGroup1, sweepGroup2]}
 

--- a/examples/04-gray-scott/cheetah-campaign.py
+++ b/examples/04-gray-scott/cheetah-campaign.py
@@ -90,5 +90,5 @@ class GrayScott(Campaign):
                                 )
     
     # Activate the SweepGroup
-    sweeps = [sweepGroup1]
+    sweeps = {'MACHINE_ANY':[sweepGroup1]}
 

--- a/examples/05-gray-scott-compression/gs.py
+++ b/examples/05-gray-scott-compression/gs.py
@@ -15,7 +15,7 @@ class GrayScott(Campaign):
         }
     }
     umask = '027'
-    sweeps = [
+    sweeps = {'MACHINE_ANY':[
      p.SweepGroup(name="gsc",
                   walltime=timedelta(minutes=30),
                   component_subdirs=True,
@@ -37,5 +37,5 @@ class GrayScott(Campaign):
           p.ParamRunner('compression', 'nprocs', [1] )          
         ]),
       ]),
-    ]
+    ]}
 


### PR DESCRIPTION
The `sweeps` variable in the Campaign class can now be a dictionary that maps machine names to sweep groups. E.g.:

`sweeps = {'MACHINE_ANY': [sweepGroup1], 'summit': [sweepGroup2, sweepGroup3], 'local':[sweepGroup4]}`

To provide backward compatibility, `sweeps` may just be a list of sweep groups.