### PR TITLE
Allow user-defined scheduler submission arguments

### DIFF
--- a/codar/cheetah/data/scheduler/cobalt/group/submit.sh
+++ b/codar/cheetah/data/scheduler/cobalt/group/submit.sh
@@ -34,6 +34,7 @@ OUTPUT=$(qsub \
         --nodecount=$CODAR_CHEETAH_GROUP_NODES \
         --time $HMS_WALLTIME \
         --jobname="$CODAR_CHEETAH_CAMPAIGN_NAME-$CODAR_CHEETAH_GROUP_NAME" \
+		$CODAR_CHEETAH_SCHEDULER_CUSTOM \
         run-group.cobalt)
 
 rval=$?

--- a/codar/cheetah/data/scheduler/ibm_lsf/group/submit.sh
+++ b/codar/cheetah/data/scheduler/ibm_lsf/group/submit.sh
@@ -42,6 +42,7 @@ OUTPUT=$(bsub \
         -W $LSF_WALLTIME \
         -alloc_flags "gpudefault NVME" \
         $extra_args \
+		$CODAR_CHEETAH_SCHEDULER_CUSTOM \
         run-group.lsf)
 
 rval=$?

--- a/codar/cheetah/data/scheduler/pbs/group/submit.sh
+++ b/codar/cheetah/data/scheduler/pbs/group/submit.sh
@@ -34,6 +34,7 @@ OUTPUT=$(qsub \
         -N "$CODAR_CHEETAH_CAMPAIGN_NAME-$CODAR_CHEETAH_GROUP_NAME" \
         -l nodes=$CODAR_CHEETAH_GROUP_NODES \
         -l walltime=$PBS_WALLTIME \
+		$CODAR_CHEETAH_SCHEDULER_CUSTOM \
         run-group.pbs)
 
 rval=$?

--- a/codar/cheetah/data/scheduler/slurm/group/submit.sh
+++ b/codar/cheetah/data/scheduler/slurm/group/submit.sh
@@ -51,6 +51,7 @@ OUTPUT=$(sbatch --parsable \
         --nodes=$CODAR_CHEETAH_GROUP_NODES \
         --time=$SLURM_WALLTIME \
         $extra_args \
+		$CODAR_CHEETAH_SCHEDULER_CUSTOM \
         run-group.sbatch)
 
 rval=$?

--- a/codar/cheetah/launchers.py
+++ b/codar/cheetah/launchers.py
@@ -362,6 +362,7 @@ class Launcher(object):
             account=scheduler_options.get('project', ''),
             queue=scheduler_options.get('queue', ''),
             reservation=scheduler_options.get('reservation', ''),
+            custom=scheduler_options.get('custom', ''),
             # TODO: require name be valid for all schedulers
             campaign_name='codar.cheetah.'+campaign_name,
             group_name=group_name,

--- a/codar/cheetah/templates.py
+++ b/codar/cheetah/templates.py
@@ -30,6 +30,9 @@ export CODAR_CHEETAH_SCHEDULER_CONSTRAINT="{constraint}"
 export CODAR_CHEETAH_SCHEDULER_LICENSE="{license}"
 export CODAR_CHEETAH_SCHEDULER_RESERVATION="{reservation}"
 
+# User-defined
+export CODAR_CHEETAH_SCHEDULER_CUSTOM="{custom}"
+
 export CODAR_CHEETAH_CAMPAIGN_NAME="{campaign_name}"
 
 export CODAR_CHEETAH_GROUP_NAME="{group_name}"

--- a/codar/savanna/machines.py
+++ b/codar/savanna/machines.py
@@ -11,7 +11,7 @@ import pdb
 # possible. For example, queue is mapped to partition on cori/slurm.
 # TODO: deeper validation, probably bring back a scheduler model.
 SCHEDULER_OPTIONS = {"project", "queue", "constraint", "license",
-                     "reservation"}
+                     "reservation", "custom"}
 
 
 class MachineNode:
@@ -168,55 +168,57 @@ cori = Machine('cori', "slurm", "srun", MachineNode,
                scheduler_options=dict(project="",
                                       queue="debug",
                                       constraint="haswell",
-                                      license="SCRATCH,project"))
+                                      license="SCRATCH,project",
+                                      custom=""))
 
 sdg_tm76 = Machine('sdg_tm76', "slurm", "srun", MachineNode,
                 processes_per_node=96, node_exclusive=True,
                 dataspaces_servers_per_node=1, # needs to be removed
                 scheduler_options=dict(project="", queue="default",
-                                       reservation=""))
+                                       reservation="", custom=""))
 
 rhea = Machine('rhea', "slurm", "srun", MachineNode,
                 processes_per_node=16, node_exclusive=True,
                 dataspaces_servers_per_node=1, # needs to be removed
                 scheduler_options=dict(project="",queue="batch",
-                                       reservation=""))
+                                       reservation="", custom=""))
 
 rhea_gpu = Machine('rhea_gpu', "slurm", "srun", MachineNode,
                 processes_per_node=14, node_exclusive=True,
                 dataspaces_servers_per_node=1, # needs to be removed
-                scheduler_options=dict(project="",queue="gpu", reservation=""))
+                scheduler_options=dict(project="",queue="gpu", reservation="", custom=""))
 
 andes = Machine('andes', "slurm", "srun", MachineNode,
                 processes_per_node=32, node_exclusive=True,
                 dataspaces_servers_per_node=1, # needs to be removed
                 scheduler_options=dict(project="",queue="batch",
-                                       reservation=""))
+                                       reservation="", custom=""))
 
 andes_gpu = Machine('andes_gpu', "slurm", "srun", MachineNode,
                 processes_per_node=28, node_exclusive=True,
                 dataspaces_servers_per_node=1, # needs to be removed
-                scheduler_options=dict(project="",queue="gpu", reservation=""))
+                scheduler_options=dict(project="",queue="gpu", reservation="", custom=""))
 
 theta = Machine('theta', "cobalt", "aprun", MachineNode,
                 processes_per_node=64, node_exclusive=True,
                 dataspaces_servers_per_node=8,
                 scheduler_options=dict(project="",
-                                       queue="debug-flat-quad"))
+                                       queue="debug-flat-quad",
+                                       custom=""))
 
 
 summit = Machine('summit', "ibm_lsf", "jsrun", SummitNode,
                  processes_per_node=42, node_exclusive=True,
-                 scheduler_options=dict(project="", reservation=""))
+                 scheduler_options=dict(project="", reservation="", custom=""))
 
 
 deepthought2_cpu = Machine('deepthought2_cpu', "slurm", "mpirunc", DTH2CPUNode,
                            processes_per_node=20, node_exclusive=False,
-                           scheduler_options=dict(project="", queue="default"))
+                           scheduler_options=dict(project="", queue="default", custom=""))
 
 deepthought2_gpu = Machine('deepthought2_gpu', "slurm", "mpirung", DTH2GPUNode,
                            processes_per_node=20, node_exclusive=False,
-                           scheduler_options=dict(project="", queue="default"))
+                           scheduler_options=dict(project="", queue="default", custom=""))
 
 
 def get_by_name(name):


### PR DESCRIPTION
It would be good if users could add their own extra arguments on submission to the scheduler, which is related to a [request](https://github.com/wdmapp/effis/issues/10) with EFFIS.