### PR TITLE
Removed redirection operators > and 2> from args as it messes up jsru…

### DIFF
--- a/codar/savanna/runners.py
+++ b/codar/savanna/runners.py
@@ -93,7 +93,8 @@ class SummitRunner(Runner):
 
         #--------------------------------------------------------------------#
         # #241: ERF files broken on Summit. Switch to regular jsrun options.
-        # This disables MPMD runs, which is handled in cheetah.model .
+        # This disables MPMD runs and node sharing, which is handled in
+        # cheetah.model .
         return self._wrap_jsrun_noerf(run, sched_args)
         # --------------------------------------------------------------------#
 


### PR DESCRIPTION
…n default options.

Not using shell scripts to run on Summit. Directly invoking an executable.
This will cause issues with MPMD, but ignore for now.